### PR TITLE
Fix SSH ready() method failing to connect

### DIFF
--- a/src/ssh.js
+++ b/src/ssh.js
@@ -24,22 +24,29 @@ class SSHConnector {
     }
 
     async ready() {
-        new Promise((resolve, reject) => {
-            for (let c = 0; c < 5; c++) {
-                var conn = new Client();
-                conn.on('ready', function () {
-                    console.log('Client :: ready');
-                    resolve('true');
-                }).on('error', function (err) {
-                }).connect({
-                    host: this.sshConfig.hostname,
-                    port: this.sshConfig.port,
-                    username: this.sshConfig.user,
-                    privateKey: fs.readFileSync(this.sshConfig.private_key),
-                    readyTimeout: 20000,
+        let counter = 0;
+        while (counter++ <= 5) {
+            try {
+                await new Promise((resolve, reject) => {
+                   var conn = new Client();
+                   conn.on('ready', function () {
+                       // console.log('Client :: ready');
+                       resolve(true);
+                   }).on('error', function (err) {
+                       reject(err);
+                   }).connect({
+                       host: this.sshConfig.hostname,
+                       port: this.sshConfig.port,
+                       username: this.sshConfig.user,
+                       privateKey: fs.readFileSync(this.sshConfig.private_key),
+                       readyTimeout: 20000,
+                   });
                 });
+                return;
+            } catch (e) {
+                // console.log(`ready error: ${e}`);
             }
-        });
+        }
     }
 
     async setup(context, setup) {


### PR DESCRIPTION
The ready() method originally spun up 5 SSH connections one after
another, but if the port on the host wasn't available, they would all
fail without waiting for the timeout.

Creating one connection at a time and waiting for it to fully time out
to start a new connection fixes this issue.